### PR TITLE
removed warnings with php 7.2

### DIFF
--- a/site/server.php
+++ b/site/server.php
@@ -156,8 +156,8 @@ if(isset($_POST['massaction']))
 	}
 $serverlist=$ts3->getElement('data', $ts3->serverList());
 
-$allslots='';
-$allusedslots='';
+$allslots=0;
+$allusedslots=0;
 if(!empty($serverlist))
 	{
 	foreach($serverlist AS $key => $value)


### PR DESCRIPTION
Tiny PR that removed the warnings in my installation with php7.2.
Since that code is supposed to count, I guess 0 is the better init value compared to an empty string.